### PR TITLE
Adding user not found exception

### DIFF
--- a/travisleak.py
+++ b/travisleak.py
@@ -69,11 +69,11 @@ def get_strings_of_set(word, char_set, threshold=20):
         strings.append(letters)
     return strings
 
-                                             
-
-
-for c in json_string['repositories']:
-	slug.append(c["slug"])
+try:
+    for c in json_string['repositories']:
+        slug.append(c["slug"])
+except:
+    print("[!] %s: User Not Found!" % (uname))
 
 for i in slug:
 	url2 = "https://api.travis-ci.org/repo/"+ urllib.parse.quote(i, safe='')  +"?include=repository.current_build"


### PR DESCRIPTION
Currently when a user supplies a Travis-ci owner name which does not exist following KeyError occurs
```
# python travisleak.py thisuserdoesnotexist
 _                   _     _            _    
| |_ _ __ __ ___   _(_)___| | ___  __ _| | __
| __| '__/ _` \ \ / / / __| |/ _ \/ _` | |/ /
| |_| | | (_| |\ V /| \__ \ |  __/ (_| |   < 
 \__|_|  \__,_| \_/ |_|___/_|\___|\__,_|_|\_\\




Traceback (most recent call last):
  File "try.py", line 75, in <module>
    for c in json_string['repositories']:
KeyError: 'repositories'
```
It's better to catch this error message and let user know that the target travis-ci user does not exist.

```
# python travisleak.py thisuserdoesnotexist
 _                   _     _            _    
| |_ _ __ __ ___   _(_)___| | ___  __ _| | __
| __| '__/ _` \ \ / / / __| |/ _ \/ _` | |/ /
| |_| | | (_| |\ V /| \__ \ |  __/ (_| |   < 
 \__|_|  \__,_| \_/ |_|___/_|\___|\__,_|_|\_\\




[!] thisuserdoesnotexist: User Not Found!
```
